### PR TITLE
Bugfix to get case weights working.

### DIFF
--- a/core/src/forest/Forest.cpp
+++ b/core/src/forest/Forest.cpp
@@ -24,6 +24,13 @@ Forest Forest::create(std::vector<std::shared_ptr<Tree>> trees,
   size_t num_types = observables.size();
   size_t num_samples = data->get_num_rows();
 
+  for (auto it : observables) {
+    size_t type = it.first;
+    if (type >= num_types) {
+      num_types = type + 1;
+    }
+  }
+
   std::vector<std::vector<double>> observations_by_type(num_types);
   std::set<size_t> disallowed_split_variables;
 


### PR DESCRIPTION
I was previously running into segmentation faults when trying to run the R package with case weights, due to `num_types` not being set properly.

Introducing the logic to set `num_types` from [ForestTrainer.cpp](https://github.com/tonyduan/grf/blob/master/core/src/forest/ForestTrainer.cpp#L47) seems to have fixed the issue.